### PR TITLE
Display videos at half fps

### DIFF
--- a/src/Composition.tsx
+++ b/src/Composition.tsx
@@ -1,3 +1,4 @@
+import {Freeze, useCurrentFrame} from 'remotion';
 import {useEffect, useState} from 'react';
 import {
 	continueRender,
@@ -56,16 +57,19 @@ const VideoCard = ({src}: {src: string}) => {
 	const {durationInSeconds} = useVideoMetaData(src);
 	const {fps} = useVideoConfig();
 	const durationInFrames = Math.floor(durationInSeconds * fps);
+	const frame = useCurrentFrame();
 
 	return (
 		<div className="w-full h-full">
 			{durationInFrames > 0 ? (
 				<Loop durationInFrames={durationInFrames} layout="none">
-					<Video
-						muted
-						src={src}
-						className="w-full h-full object-cover rounded-lg shadow"
-					/>
+					<Freeze frame={Math.floor(frame / 2.0) * 2.0}>
+						<Video
+							muted
+							src={src}
+							className="w-full h-full object-cover rounded-lg shadow"
+						/>
+					</Freeze>
 				</Loop>
 			) : null}
 		</div>


### PR DESCRIPTION
This change has the effect of rendering the videos at half of the fps of the composition (15fps).   This improves the render time by 2x while making the preview player very choppy and inaccurate.

For the ``Videos-16` composition, render time was improved to 71s. 

This may be a viable workaround for improved render times depending on the user's needs. 